### PR TITLE
persist sgstore.ignore to localstorage

### DIFF
--- a/TinyMCE5/languagetool/include/languagetool.min.js
+++ b/TinyMCE5/languagetool/include/languagetool.min.js
@@ -11,7 +11,7 @@ var LanguageTool = function LanguageTool(lt_set,$) {
 
 // Declare Variables
  var lt_localstorage = lt_set['lt_localstorage'];
- var ignore = lt_localstorage ? JSON.parse(localstorage[lt_localstorage]) : { once:{}, all:{}, rule:{}, categories:{} };
+ var ignore = lt_localstorage && localStorage[lt_localstorage] ? JSON.parse(localStorage[lt_localstorage]) : { once:{}, all:{}, rule:{}, categories:{} };
   
  var sgevent = {}; // Events that can be called
  var sgfunc = {}; // Store functions
@@ -1646,7 +1646,7 @@ sgfunc['confirm'].call(this,'Are you sure you wish to ignore this rule going for
                 }
 
         if (lt_localstorage) {
-            localstorage[lt_localstorage] = JSON.stringify(sgstore.ignore);
+            localStorage[lt_localstorage] = JSON.stringify(sgstore.ignore);
         }
 
         }

--- a/TinyMCE5/languagetool/include/languagetool.min.js
+++ b/TinyMCE5/languagetool/include/languagetool.min.js
@@ -10,12 +10,15 @@
 var LanguageTool = function LanguageTool(lt_set,$) {
 
 // Declare Variables
+ var lt_localstorage = lt_set['lt_localstorage'];
+ var ignore = lt_localstorage ? JSON.parse(localstorage[lt_localstorage]) : { once:{}, all:{}, rule:{}, categories:{} };
+  
  var sgevent = {}; // Events that can be called
  var sgfunc = {}; // Store functions
  var sgcheck = {}; // Active storage of changes
  var sgdocevents = {}; // Events called on document
  var sgewinevents={}; // Events caleld on editor window
- var sgstore = { html:{}, text:{}, obj:{}, lt:{}, lock:{}, run:[], contextmenu:{}, ignore:{ once:{}, all:{}, rule:{}, categories:{}}, queue:[[],[],[]], dqueue:{}, iaqueue:{}, progress:[0,0,0,0], issues:{}, viewport_process:'disabled', enabled: true  }; // Universal Storage
+ var sgstore = { html:{}, text:{}, obj:{}, lt:{}, lock:{}, run:[], contextmenu:{}, ignore:ignore, queue:[[],[],[]], dqueue:{}, iaqueue:{}, progress:[0,0,0,0], issues:{}, viewport_process:'disabled', enabled: true  }; // Universal Storage
  var timerRunner = 0; // Timer coundown for remote url (counts upwards though)
  var lastActive=0; // Last activity for hibernation
  var lastRun=0; // Keep track of when time last ran in epoch
@@ -55,8 +58,8 @@ var LanguageTool = function LanguageTool(lt_set,$) {
 
  sgstore.viewport_process = lt_set['lt_viewport_process'] || 'disabled';
 
- sgstore['ignore']['all']=lt_set['lt_ignore_words'] || {};
- sgstore['ignore']['rule']=lt_set['lt_ignore_rules'] || {};
+ Object.assign(sgstore['ignore']['all'], lt_set['lt_ignore_words'] || {});
+ Object.assign(sgstore['ignore']['rule'], lt_set['lt_ignore_rules'] || {});
 
 
  lt_setHighlight['misspelling'] = lt_setHighlight['misspelling'] || "hlr1";
@@ -1641,7 +1644,10 @@ sgfunc['confirm'].call(this,'Are you sure you wish to ignore this rule going for
 });
 
                 }
-         
+
+        if (lt_localstorage) {
+            localstorage[lt_localstorage] = JSON.stringify(sgstore.ignore);
+        }
 
         }
 


### PR DESCRIPTION
As covered in #11 

Works by adding an `lt_localstorage` setting, which is the name of the localstorage key that the ignore settings will be persisted to, just in case you want to have different ones in the same browser, i.e. by username or some such.

Note that rules injected via the settings will be persisted in localstorage, so changing those settings will be difficult.  But this is only a problem if you are doing both (hardcoded rules plus localstorage).

I'm going to test this out before I take it off Draft.